### PR TITLE
bug/0001_missing_authors_fix

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,22 @@
 bing_api_key = "your_key_here"
 
-############## CUSTOM EXCEPTION ##############
+############## CUSTOM EXCEPTIONS ##############
 class EmptyDictionaryError(Exception):
-    """Raised when the books_data dictionary is empty. This suggests the web scraping has totally failed, which is likely due to an incorrect URL or an incompatible Humble Bunde webpage structure relative to this script."""
+    """
+    Exception raised when the books_data dictionary is empty.
+    
+    Typically indicates that web scraping failed, possibly due to an incorrect URL or an incompatible Humble Bundle webpage structure.
+    
+    Check the URL and the expected HTML structure relative to the HTML fields parsed for Publisher, Title, Author(s), Blurb.
+    """
+    pass
+
+class MismatchError(Exception):
+    """
+    Exception raised when the counts of titles, authors, and blurbs parsed from the Humble Bundle HTML content do not match.
+    
+    This mismatch prevents the creation of a coherent books_data dictionar. Script termination is enacted to avoid erroneous API calls or misleading txt file content
+    
+    Ensure the webpage structure is compatible with the HTML parsing logic.
+    """
     pass

--- a/hb_book_info_main.py
+++ b/hb_book_info_main.py
@@ -7,7 +7,7 @@ from config import bing_api_key
 
 ############## MANUAL INPUTS ##############
 """ Give the URL of the Humble Book Bundle you wish to target. """
-url_hb = "https://www.humblebundle.com/books/cory-doctorow-novel-collection-tor-books-books"
+url_hb = "https://www.humblebundle.com/books/electronics-and-design-for-entrepreneurs-make-books"
 
 """ Choose the browser you want to use for the Selenium web scraping.
 Options: 'Chrome', 'Firefox', 'Safari', 'Opera', 'Edge', 'Internet Explorer'

--- a/hb_book_info_utils.py
+++ b/hb_book_info_utils.py
@@ -14,7 +14,7 @@ import time
 from urllib.parse import quote
 import webbrowser
 
-from config import EmptyDictionaryError
+from config1 import EmptyDictionaryError, MismatchError
 
 
 ############### CHECK / CREATE OUTPUT FOLDER FUNCTIONALITY #################
@@ -120,8 +120,8 @@ def hb_webpage_selenium(url_hb, selenium_browser, debug_flag, debug_directory):
 
 ############### HUMBLE BUNDLE WEBPAGE PARSING FUNCTIONALITY #################
 
-def parse_hb_webpage(soup1, soup2):
-    """Parse HumbleBunde webpage for book data"""
+def parse_hb_webpage(soup1, soup2, debug_flag, debug_directory):
+    """Parse HumbleBundle webpage for books data."""
 
     # Translation table for removing invalid characters from web-retreived strings (HumbleBundle titles often contain :,  which will corrupt filename)
     invalid_chars = '<>:"/\\|?*'
@@ -131,22 +131,24 @@ def parse_hb_webpage(soup1, soup2):
     try:
         # Parse the HTML content retrieved by requests using BeautifulSoup
         bundle_data = soup1.find('script', {'id': 'webpack-bundle-page-data'})
-        json_content = json.loads(bundle_data.string)
+        if bundle_data:
+            json_content = json.loads(bundle_data.string)
 
-        # Extract publisher
-        bundle_publisher = json_content['bundleData']['author'].translate(trans_table)
-        print(f"Publisher: {bundle_publisher}")
+            # Extract publisher
+            bundle_publisher = json_content['bundleData']['author'].translate(trans_table)
+            print(f"Publisher: {bundle_publisher}")
 
-        # Extract bundle name
-        bundle_name = json_content['bundleData']['basic_data']['human_name'].translate(trans_table)
-        print(f"Bundle name: {bundle_name}")
+            # Extract bundle name
+            bundle_name = json_content['bundleData']['basic_data']['human_name'].translate(trans_table)
+            print(f"Bundle name: {bundle_name}")
 
-        if not bundle_name: # another method for bundle name
-            bundle_name_pattern = soup1.find('script', {'type': 'application/ld+json'})
-            json_content = json.loads(bundle_name_pattern.string)
-            bundle_name = json_content['name'].translate(trans_table)
-
-
+            if not bundle_name: # another method for bundle name
+                bundle_name_pattern = soup1.find('script', {'type': 'application/ld+json'})
+                if bundle_name_pattern:
+                    json_content = json.loads(bundle_name_pattern.string)
+                    bundle_name = json_content['name'].translate(trans_table)
+        else: 
+            bundle_name, bundle_publisher = "Unknown", "Unknown"
         # Parse the HTML-js content retrieved by Selenium using BeautifulSoup
         # Extract book titles
         title_pattern = re.compile(r'item-title') 

--- a/hb_book_info_utils.py
+++ b/hb_book_info_utils.py
@@ -15,7 +15,7 @@ import time
 from urllib.parse import quote
 import webbrowser
 
-from config1 import EmptyDictionaryError, MismatchError
+from config import EmptyDictionaryError, MismatchError
 
 
 ############### CHECK / CREATE OUTPUT FOLDER FUNCTIONALITY #################


### PR DESCRIPTION
PR fixes the Issue #1 bug whereby the code failed to handle books which were missing Author fields/values on the Humble Book Bundle webpage. 

Main changes:
`hb_book_info_utils.py`: 
- `parse_hb_webpage` function: added fallback incase `bundle_name` or `bundle_publisher` not retrieved correctly. Total rewrite and expansion of the `soup2` parsing functionality for the Author(s) HTML element - code now detects if an Author(s) section is missing and substitutes a placeholder div of the correct structure and placement. Essentially "Unknown" will be substituted to preserve positional synchronisation between Title-Author(s)-Blurb for each book. Debug sections added, console warning added incase of mismatches and custom MismatchError exception created. Exceptions raised in this function now trigger script exit to prevent erroneous API calls or misleading txt output.

- `catalogue_book_data`: control of multiple Author spans moved from this function to `parse_hb_webpage`.

`config.py`: MismatchError custom Exception added